### PR TITLE
[CXH-1117] Add service accounts as resources

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -12,12 +12,13 @@ ConductorOne currently only integrates with Snyk Enterprise. ConductorOne can on
 
 ## Capabilities
 
-| Resource     | Sync | Provision |
-| ------------ | ---- | --------- |
-| Accounts     | <Icon icon="square-check" iconType="solid"  color="#65DE23"/>   |           |       
-| Groups       | <Icon icon="square-check" iconType="solid"  color="#65DE23"/>    |   | 
-| Organizations     | <Icon icon="square-check" iconType="solid"  color="#65DE23"/>    | <Icon icon="square-check" iconType="solid"  color="#65DE23"/>  |
-| Invitations     | <Icon icon="square-check" iconType="solid"  color="#65DE23"/>    | <Icon icon="square-check" iconType="solid"  color="#65DE23"/>  |
+| Resource         | Sync | Provision |
+| ---------------- | ---- | --------- |
+| Accounts         | <Icon icon="square-check" iconType="solid"  color="#65DE23"/>   |           |
+| Groups           | <Icon icon="square-check" iconType="solid"  color="#65DE23"/>    |   |
+| Organizations    | <Icon icon="square-check" iconType="solid"  color="#65DE23"/>    | <Icon icon="square-check" iconType="solid"  color="#65DE23"/>  |
+| Invitations      | <Icon icon="square-check" iconType="solid"  color="#65DE23"/>    | <Icon icon="square-check" iconType="solid"  color="#65DE23"/>  |
+| Service Accounts | <Icon icon="square-check" iconType="solid"  color="#65DE23"/>    |   |
 
 ## Gather Snyk credentials 
 

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
-	google.golang.org/grpc v1.78.0 // indirect
+	google.golang.org/grpc v1.78.0 
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -32,9 +32,10 @@ const (
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (s *Snyk) ResourceSyncers(_ context.Context) []connectorbuilder.ResourceSyncer {
 	return []connectorbuilder.ResourceSyncer{
-		newGroupBuilder(s.client, s.GroupID, s.Orgs),
+		newGroupBuilder(s.client, s.Orgs),
 		newOrgBuilder(s.client, s.Orgs),
 		newUserBuilder(s.client),
+		newServiceAccountBuilder(s.client),
 		newInvitationBuilder(s.client, s.Orgs),
 	}
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -32,7 +32,7 @@ const (
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (s *Snyk) ResourceSyncers(_ context.Context) []connectorbuilder.ResourceSyncer {
 	return []connectorbuilder.ResourceSyncer{
-		newGroupBuilder(s.client, s.Orgs),
+		newGroupBuilder(s.client),
 		newOrgBuilder(s.client, s.Orgs),
 		newUserBuilder(s.client),
 		newServiceAccountBuilder(s.client),

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -12,8 +12,6 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-snyk/pkg/snyk"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 )
 
 // Group role constants for Snyk.
@@ -27,7 +25,6 @@ var groupRoles = []string{AdminRole, MemberRole, ViewerRole}
 
 type groupBuilder struct {
 	client *snyk.Client
-	ID     string
 	orgs   map[string]struct{}
 }
 
@@ -51,6 +48,7 @@ func groupResource(_ context.Context, group *snyk.Group) (*v2.Resource, error) {
 		rs.WithAnnotation(
 			&v2.ChildResourceType{ResourceTypeId: orgResourceType.Id},
 			&v2.ChildResourceType{ResourceTypeId: userResourceType.Id},
+			&v2.ChildResourceType{ResourceTypeId: serviceAccountResourceType.Id},
 		),
 	)
 	if err != nil {
@@ -68,7 +66,7 @@ func (g *groupBuilder) List(ctx context.Context, _ *v2.ResourceId, _ *pagination
 	// get details from orgs endpoint
 	groupDetail, err := g.client.GetGroupDetails(ctx)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("failed to get group details: %w", err)
+		return nil, "", nil, fmt.Errorf("snyk-connector: failed to get group details: %w", err)
 	}
 
 	gr, err := groupResource(ctx, groupDetail)
@@ -107,7 +105,7 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 		return nil, "", nil, fmt.Errorf("snyk-connector: failed to list users in group: %w", err)
 	}
 
-	// Get all organizations in the group to create member grants for group admins
+	// Collect all orgs so we can create explicit member grants for human group admins.
 	var orgResources []*v2.Resource
 	pageToken := ""
 	for {
@@ -116,14 +114,11 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 			return nil, "", nil, fmt.Errorf("snyk-connector: failed to list orgs: %w", err)
 		}
 
-		// Build org resources, applying the same filter as orgBuilder
 		for _, org := range orgs {
-			// Filter by org IDs if filter is specified
 			if _, ok := g.orgs[org.ID]; !ok && len(g.orgs) > 0 {
 				continue
 			}
-
-			orgResource, err := rs.NewGroupResource(
+			orgRes, err := rs.NewGroupResource(
 				org.Name,
 				orgResourceType,
 				org.ID,
@@ -133,23 +128,14 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 			if err != nil {
 				return nil, "", nil, fmt.Errorf("snyk-connector: failed to create org resource: %w", err)
 			}
-			orgResources = append(orgResources, orgResource)
+			orgResources = append(orgResources, orgRes)
 		}
 
-		// Check if there are more pages
 		nextPage, err := parseLink(nextPageLink)
 		if err != nil {
-			// parseLink returns an error when there's no "next" link, which is expected at the end
-			// If it's an unexpected error, we should propagate it since pagination is critical
-			// for ensuring group admins get member grants for all organizations
 			if err.Error() != "no next link found in header" {
-				l := ctxzap.Extract(ctx)
-				l.Error("snyk-connector: error parsing pagination link",
-					zap.String("link", nextPageLink),
-					zap.Error(err))
 				return nil, "", nil, fmt.Errorf("snyk-connector: failed to parse pagination link: %w", err)
 			}
-			// No more pages, which is expected
 			break
 		}
 		if nextPage == "" {
@@ -158,32 +144,89 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 		pageToken = nextPage
 	}
 
-	// permission grants
+	// Build an authoritative set of group SA IDs from the REST API.
+	// The v1 members endpoint returns both group SAs and org SAs (email == "").
+	// We discriminate by the "level" field: only "Group" SAs get group role grants.
+	groupSAIDs := make(map[string]struct{})
+	saPageToken := ""
+	for {
+		saResp, saLink, err := g.client.ListGroupServiceAccounts(ctx, saPageToken)
+		if err != nil {
+			return nil, "", nil, fmt.Errorf("snyk-connector: failed to list group service accounts: %w", err)
+		}
+		for _, sa := range saResp.Data {
+			if sa.Attributes.Level == "Group" {
+				groupSAIDs[sa.ID] = struct{}{}
+			}
+		}
+		saPageToken = parseRestNextLink(saLink)
+		if saPageToken == "" {
+			break
+		}
+	}
+
+	groupAdminEntID := fmt.Sprintf("%s:%s:%s", groupResourceType.Id, resource.Id.Resource, AdminRole)
+
 	for _, member := range members {
+		if member.Email == "" {
+			// Only emit grants for actual group SAs; org SAs also appear in this endpoint.
+			if _, isGroupSA := groupSAIDs[member.ID]; !isGroupSA {
+				continue
+			}
+			// Service account: emit group role grant directly from the resolved slug.
+			if !slices.Contains(groupRoles, member.Role) {
+				continue
+			}
+			saIDRes, err := rs.NewResourceID(serviceAccountResourceType, member.ID)
+			if err != nil {
+				return nil, "", nil, fmt.Errorf("snyk-connector: failed to create service account resource id: %w", err)
+			}
+			rv = append(rv, grant.NewGrant(resource, member.Role, saIDRes))
+			// Group admin SAs have implicit membership in all orgs, just like human group admins.
+			if member.Role == AdminRole {
+				for _, orgRes := range orgResources {
+					saGrant := grant.NewGrant(
+						orgRes,
+						OrgMemberEntitlement,
+						saIDRes,
+						grant.WithAnnotation(&v2.GrantImmutable{}),
+					)
+					saGrant.SetSources(v2.GrantSources_builder{
+						Sources: map[string]*v2.GrantSources_GrantSource{
+							groupAdminEntID: {IsDirect: true},
+						},
+					}.Build())
+					rv = append(rv, saGrant)
+				}
+			}
+			continue
+		}
+
 		userID, err := rs.NewResourceID(userResourceType, member.ID)
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("snyk-connector: failed to create user resource id: %w", err)
 		}
 
-		if slices.Contains(groupRoles, member.Role) {
-			// Create the group role grant
-			rv = append(rv, grant.NewGrant(resource, member.Role, userID))
+		if !slices.Contains(groupRoles, member.Role) {
+			continue
+		}
 
-			// For group admins, create "member" grants in all organizations
-			// Group admins have implicit access to all orgs in the group
-			if member.Role == AdminRole {
-				for _, orgResource := range orgResources {
-					// Create a grant with GrantImmutable annotation to mark it as immutable
-					// This ensures the grant won't be updated or revoked, since group admins
-					// have implicit access to all orgs (not explicit memberships in the API)
-					memberGrant := grant.NewGrant(
-						orgResource,
-						OrgMemberEntitlement,
-						userID,
-						grant.WithAnnotation(&v2.GrantImmutable{}),
-					)
-					rv = append(rv, memberGrant)
-				}
+		rv = append(rv, grant.NewGrant(resource, member.Role, userID))
+
+		if member.Role == AdminRole {
+			for _, orgRes := range orgResources {
+				g := grant.NewGrant(
+					orgRes,
+					OrgMemberEntitlement,
+					userID,
+					grant.WithAnnotation(&v2.GrantImmutable{}),
+				)
+				g.SetSources(v2.GrantSources_builder{
+					Sources: map[string]*v2.GrantSources_GrantSource{
+						groupAdminEntID: {IsDirect: true},
+					},
+				}.Build())
+				rv = append(rv, g)
 			}
 		}
 	}
@@ -191,7 +234,7 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 	return rv, "", nil, nil
 }
 
-func newGroupBuilder(client *snyk.Client, id string, orgs []string) *groupBuilder {
+func newGroupBuilder(client *snyk.Client, orgs []string) *groupBuilder {
 	orgMap := make(map[string]struct{}, len(orgs))
 	for _, org := range orgs {
 		orgMap[org] = struct{}{}
@@ -199,7 +242,6 @@ func newGroupBuilder(client *snyk.Client, id string, orgs []string) *groupBuilde
 
 	return &groupBuilder{
 		client: client,
-		ID:     id,
 		orgs:   orgMap,
 	}
 }

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -144,11 +144,7 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 		default:
 		}
 
-		if member.Email == "" {
-			// Only emit grants for actual group SAs; org SAs also appear in this endpoint.
-			if _, isGroupSA := groupSAIDs[member.ID]; !isGroupSA {
-				continue
-			}
+		if _, isGroupSA := groupSAIDs[member.ID]; isGroupSA {
 			// Service account: emit group role grant directly from the resolved slug.
 			if !slices.Contains(groupRoles, member.Role) {
 				continue
@@ -161,6 +157,11 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 			if member.Role == AdminRole {
 				adminPrincipals = append(adminPrincipals, saIDRes)
 			}
+			continue
+		}
+
+		// Skip org SAs and other non-human entries that appear in the group members endpoint.
+		if member.Email == "" {
 			continue
 		}
 

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -105,51 +105,6 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 		return nil, "", nil, fmt.Errorf("snyk-connector: failed to list users in group: %w", err)
 	}
 
-	// Collect all orgs so we can create explicit member grants for human group admins.
-	var orgResources []*v2.Resource
-	pageToken := ""
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, "", nil, ctx.Err()
-		default:
-		}
-
-		orgs, nextPageLink, err := g.client.ListOrgs(ctx, snyk.NewPaginationVars(pageToken, ResourcesPageSize))
-		if err != nil {
-			return nil, "", nil, fmt.Errorf("snyk-connector: failed to list orgs: %w", err)
-		}
-
-		for _, org := range orgs {
-			if _, ok := g.orgs[org.ID]; !ok && len(g.orgs) > 0 {
-				continue
-			}
-			orgRes, err := rs.NewGroupResource(
-				org.Name,
-				orgResourceType,
-				org.ID,
-				[]rs.GroupTraitOption{},
-				rs.WithParentResourceID(resource.Id),
-			)
-			if err != nil {
-				return nil, "", nil, fmt.Errorf("snyk-connector: failed to create org resource: %w", err)
-			}
-			orgResources = append(orgResources, orgRes)
-		}
-
-		nextPage, err := parseLink(nextPageLink)
-		if err != nil {
-			if err.Error() != "no next link found in header" {
-				return nil, "", nil, fmt.Errorf("snyk-connector: failed to parse pagination link: %w", err)
-			}
-			break
-		}
-		if nextPage == "" {
-			break
-		}
-		pageToken = nextPage
-	}
-
 	// Build an authoritative set of group SA IDs from the REST API.
 	// The v1 members endpoint returns both group SAs and org SAs (email == "").
 	// We discriminate by the "level" field: only "Group" SAs get group role grants.
@@ -179,6 +134,9 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 
 	groupAdminEntID := fmt.Sprintf("%s:%s:%s", groupResourceType.Id, resource.Id.Resource, AdminRole)
 
+	// Emit group role grants and collect admin principal IDs for org expansion.
+	// Admins are few relative to orgs, so buffering their IDs is safe.
+	var adminPrincipals []*v2.ResourceId
 	for _, member := range members {
 		select {
 		case <-ctx.Done():
@@ -200,22 +158,8 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 				return nil, "", nil, fmt.Errorf("snyk-connector: failed to create service account resource id: %w", err)
 			}
 			rv = append(rv, grant.NewGrant(resource, member.Role, saIDRes))
-			// Group admin SAs have implicit membership in all orgs, just like human group admins.
 			if member.Role == AdminRole {
-				for _, orgRes := range orgResources {
-					saGrant := grant.NewGrant(
-						orgRes,
-						OrgMemberEntitlement,
-						saIDRes,
-						grant.WithAnnotation(&v2.GrantImmutable{}),
-					)
-					saGrant.SetSources(v2.GrantSources_builder{
-						Sources: map[string]*v2.GrantSources_GrantSource{
-							groupAdminEntID: {IsDirect: true},
-						},
-					}.Build())
-					rv = append(rv, saGrant)
-				}
+				adminPrincipals = append(adminPrincipals, saIDRes)
 			}
 			continue
 		}
@@ -232,11 +176,48 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 		rv = append(rv, grant.NewGrant(resource, member.Role, userID))
 
 		if member.Role == AdminRole {
-			for _, orgRes := range orgResources {
+			adminPrincipals = append(adminPrincipals, userID)
+		}
+	}
+
+	pageToken := ""
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, "", nil, ctx.Err()
+		default:
+		}
+
+		orgs, nextPageLink, err := g.client.ListOrgs(ctx, snyk.NewPaginationVars(pageToken, ResourcesPageSize))
+		if err != nil {
+			return nil, "", nil, fmt.Errorf("snyk-connector: failed to list orgs: %w", err)
+		}
+
+		for _, org := range orgs {
+			if _, ok := g.orgs[org.ID]; !ok && len(g.orgs) > 0 {
+				continue
+			}
+			orgRes, err := rs.NewGroupResource(
+				org.Name,
+				orgResourceType,
+				org.ID,
+				[]rs.GroupTraitOption{},
+				rs.WithParentResourceID(resource.Id),
+			)
+			if err != nil {
+				return nil, "", nil, fmt.Errorf("snyk-connector: failed to create org resource: %w", err)
+			}
+
+			for _, principalID := range adminPrincipals {
+				select {
+				case <-ctx.Done():
+					return nil, "", nil, ctx.Err()
+				default:
+				}
 				orgGrant := grant.NewGrant(
 					orgRes,
 					OrgMemberEntitlement,
-					userID,
+					principalID,
 					grant.WithAnnotation(&v2.GrantImmutable{}),
 				)
 				orgGrant.SetSources(v2.GrantSources_builder{
@@ -247,6 +228,18 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 				rv = append(rv, orgGrant)
 			}
 		}
+
+		nextPage, err := parseLink(nextPageLink)
+		if err != nil {
+			if err.Error() != "no next link found in header" {
+				return nil, "", nil, fmt.Errorf("snyk-connector: failed to parse pagination link: %w", err)
+			}
+			break
+		}
+		if nextPage == "" {
+			break
+		}
+		pageToken = nextPage
 	}
 
 	return rv, "", nil, nil

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -109,6 +109,12 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 	var orgResources []*v2.Resource
 	pageToken := ""
 	for {
+		select {
+		case <-ctx.Done():
+			return nil, "", nil, ctx.Err()
+		default:
+		}
+
 		orgs, nextPageLink, err := g.client.ListOrgs(ctx, snyk.NewPaginationVars(pageToken, ResourcesPageSize))
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("snyk-connector: failed to list orgs: %w", err)
@@ -150,6 +156,12 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 	groupSAIDs := make(map[string]struct{})
 	saPageToken := ""
 	for {
+		select {
+		case <-ctx.Done():
+			return nil, "", nil, ctx.Err()
+		default:
+		}
+
 		saResp, saLink, err := g.client.ListGroupServiceAccounts(ctx, saPageToken)
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("snyk-connector: failed to list group service accounts: %w", err)

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -227,18 +227,18 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 
 		if member.Role == AdminRole {
 			for _, orgRes := range orgResources {
-				g := grant.NewGrant(
+				orgGrant := grant.NewGrant(
 					orgRes,
 					OrgMemberEntitlement,
 					userID,
 					grant.WithAnnotation(&v2.GrantImmutable{}),
 				)
-				g.SetSources(v2.GrantSources_builder{
+				orgGrant.SetSources(v2.GrantSources_builder{
 					Sources: map[string]*v2.GrantSources_GrantSource{
 						groupAdminEntID: {IsDirect: true},
 					},
 				}.Build())
-				rv = append(rv, g)
+				rv = append(rv, orgGrant)
 			}
 		}
 	}

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -36,7 +36,6 @@ type groupGrantState struct {
 
 type groupBuilder struct {
 	client *snyk.Client
-	orgs   map[string]struct{}
 }
 
 func (g *groupBuilder) ResourceType(_ context.Context) *v2.ResourceType {
@@ -82,7 +81,7 @@ func (g *groupBuilder) List(ctx context.Context, _ *v2.ResourceId, _ *pagination
 
 	gr, err := groupResource(ctx, groupDetail)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, fmt.Errorf("snyk-connector: failed to create group resource: %w", err)
 	}
 
 	rv = append(rv, gr)
@@ -201,14 +200,8 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken
 	}
 }
 
-func newGroupBuilder(client *snyk.Client, orgs []string) *groupBuilder {
-	orgMap := make(map[string]struct{}, len(orgs))
-	for _, org := range orgs {
-		orgMap[org] = struct{}{}
-	}
-
+func newGroupBuilder(client *snyk.Client) *groupBuilder {
 	return &groupBuilder{
 		client: client,
-		orgs:   orgMap,
 	}
 }

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -85,7 +85,7 @@ func (g *groupBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ 
 
 	for _, role := range groupRoles {
 		permissionOptions := []ent.EntitlementOption{
-			ent.WithGrantableTo(userResourceType),
+			ent.WithGrantableTo(userResourceType, serviceAccountResourceType),
 			ent.WithDisplayName(fmt.Sprintf("%s %s", resource.DisplayName, role)),
 			ent.WithDescription(fmt.Sprintf("%s role in the %s group", role, resource.DisplayName)),
 		}
@@ -180,6 +180,12 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pag
 	groupAdminEntID := fmt.Sprintf("%s:%s:%s", groupResourceType.Id, resource.Id.Resource, AdminRole)
 
 	for _, member := range members {
+		select {
+		case <-ctx.Done():
+			return nil, "", nil, ctx.Err()
+		default:
+		}
+
 		if member.Email == "" {
 			// Only emit grants for actual group SAs; org SAs also appear in this endpoint.
 			if _, isGroupSA := groupSAIDs[member.ID]; !isGroupSA {

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -23,6 +23,17 @@ const (
 
 var groupRoles = []string{AdminRole, MemberRole, ViewerRole}
 
+const (
+	groupGrantPhaseSA      = "service_accounts"
+	groupGrantPhaseMembers = "members"
+)
+
+type groupGrantState struct {
+	Phase      string   `json:"phase"`
+	PageToken  string   `json:"page_token,omitempty"`
+	GroupSAIDs []string `json:"group_sa_ids,omitempty"`
+}
+
 type groupBuilder struct {
 	client *snyk.Client
 	orgs   map[string]struct{}
@@ -97,153 +108,97 @@ func (g *groupBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ 
 }
 
 // Grants returns all the permission grants for a group.
-func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	var rv []*v2.Grant
-
-	members, err := g.client.ListUsersInGroup(ctx)
+func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+	bag, err := pagination.GenBagFromToken[groupGrantState](pToken)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("snyk-connector: failed to list users in group: %w", err)
+		return nil, "", nil, fmt.Errorf("snyk-connector: failed to parse group grant token: %w", err)
 	}
 
-	// Build an authoritative set of group SA IDs from the REST API.
-	// The v1 members endpoint returns both group SAs and org SAs (email == "").
-	// We discriminate by the "level" field: only "Group" SAs get group role grants.
-	groupSAIDs := make(map[string]struct{})
-	saPageToken := ""
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, "", nil, ctx.Err()
-		default:
-		}
+	if bag.Current() == nil {
+		bag.Push(groupGrantState{Phase: groupGrantPhaseSA})
+	}
 
-		saResp, saLink, err := g.client.ListGroupServiceAccounts(ctx, saPageToken)
+	state := bag.Current()
+
+	switch state.Phase {
+	case groupGrantPhaseSA:
+		saResp, saLink, err := g.client.ListGroupServiceAccounts(ctx, state.PageToken)
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("snyk-connector: failed to list group service accounts: %w", err)
 		}
+
+		saIDs := make([]string, len(state.GroupSAIDs), len(state.GroupSAIDs)+len(saResp.Data))
+		copy(saIDs, state.GroupSAIDs)
 		for _, sa := range saResp.Data {
 			if sa.Attributes.Level == "Group" {
-				groupSAIDs[sa.ID] = struct{}{}
+				saIDs = append(saIDs, sa.ID)
 			}
 		}
-		saPageToken = parseRestNextLink(saLink)
-		if saPageToken == "" {
-			break
-		}
-	}
 
-	groupAdminEntID := fmt.Sprintf("%s:%s:%s", groupResourceType.Id, resource.Id.Resource, AdminRole)
-
-	// Emit group role grants and collect admin principal IDs for org expansion.
-	// Admins are few relative to orgs, so buffering their IDs is safe.
-	var adminPrincipals []*v2.ResourceId
-	for _, member := range members {
-		select {
-		case <-ctx.Done():
-			return nil, "", nil, ctx.Err()
-		default:
+		bag.Pop()
+		nextSAPage := parseRestNextLink(saLink)
+		if nextSAPage != "" {
+			bag.Push(groupGrantState{Phase: groupGrantPhaseSA, PageToken: nextSAPage, GroupSAIDs: saIDs})
+		} else {
+			bag.Push(groupGrantState{Phase: groupGrantPhaseMembers, GroupSAIDs: saIDs})
 		}
 
-		if _, isGroupSA := groupSAIDs[member.ID]; isGroupSA {
-			// Service account: emit group role grant directly from the resolved slug.
+		nextToken, err := bag.Marshal()
+		if err != nil {
+			return nil, "", nil, fmt.Errorf("snyk-connector: failed to marshal group grant token: %w", err)
+		}
+		return nil, nextToken, nil, nil
+
+	case groupGrantPhaseMembers:
+		groupSAIDsSet := make(map[string]struct{}, len(state.GroupSAIDs))
+		for _, id := range state.GroupSAIDs {
+			groupSAIDsSet[id] = struct{}{}
+		}
+
+		members, err := g.client.ListUsersInGroup(ctx)
+		if err != nil {
+			return nil, "", nil, fmt.Errorf("snyk-connector: failed to list users in group: %w", err)
+		}
+
+		var rv []*v2.Grant
+		for _, member := range members {
+			if _, isGroupSA := groupSAIDsSet[member.ID]; isGroupSA {
+				if !slices.Contains(groupRoles, member.Role) {
+					continue
+				}
+				saIDRes, err := rs.NewResourceID(serviceAccountResourceType, member.ID)
+				if err != nil {
+					return nil, "", nil, fmt.Errorf("snyk-connector: failed to create service account resource id: %w", err)
+				}
+				rv = append(rv, grant.NewGrant(resource, member.Role, saIDRes))
+				continue
+			}
+
+			// Skip org SAs and other non-human entries that appear in the group members endpoint.
+			if member.Email == "" {
+				continue
+			}
+
 			if !slices.Contains(groupRoles, member.Role) {
 				continue
 			}
-			saIDRes, err := rs.NewResourceID(serviceAccountResourceType, member.ID)
+			userID, err := rs.NewResourceID(userResourceType, member.ID)
 			if err != nil {
-				return nil, "", nil, fmt.Errorf("snyk-connector: failed to create service account resource id: %w", err)
+				return nil, "", nil, fmt.Errorf("snyk-connector: failed to create user resource id: %w", err)
 			}
-			rv = append(rv, grant.NewGrant(resource, member.Role, saIDRes))
-			if member.Role == AdminRole {
-				adminPrincipals = append(adminPrincipals, saIDRes)
-			}
-			continue
+			rv = append(rv, grant.NewGrant(resource, member.Role, userID))
 		}
 
-		// Skip org SAs and other non-human entries that appear in the group members endpoint.
-		if member.Email == "" {
-			continue
-		}
-
-		userID, err := rs.NewResourceID(userResourceType, member.ID)
+		bag.Pop()
+		nextToken, err := bag.Marshal()
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("snyk-connector: failed to create user resource id: %w", err)
+			return nil, "", nil, fmt.Errorf("snyk-connector: failed to marshal group grant token: %w", err)
 		}
+		return rv, nextToken, nil, nil
 
-		if !slices.Contains(groupRoles, member.Role) {
-			continue
-		}
-
-		rv = append(rv, grant.NewGrant(resource, member.Role, userID))
-
-		if member.Role == AdminRole {
-			adminPrincipals = append(adminPrincipals, userID)
-		}
+	default:
+		return nil, "", nil, fmt.Errorf("snyk-connector: unknown group grant phase: %s", state.Phase)
 	}
-
-	pageToken := ""
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, "", nil, ctx.Err()
-		default:
-		}
-
-		orgs, nextPageLink, err := g.client.ListOrgs(ctx, snyk.NewPaginationVars(pageToken, ResourcesPageSize))
-		if err != nil {
-			return nil, "", nil, fmt.Errorf("snyk-connector: failed to list orgs: %w", err)
-		}
-
-		for _, org := range orgs {
-			if _, ok := g.orgs[org.ID]; !ok && len(g.orgs) > 0 {
-				continue
-			}
-			orgRes, err := rs.NewGroupResource(
-				org.Name,
-				orgResourceType,
-				org.ID,
-				[]rs.GroupTraitOption{},
-				rs.WithParentResourceID(resource.Id),
-			)
-			if err != nil {
-				return nil, "", nil, fmt.Errorf("snyk-connector: failed to create org resource: %w", err)
-			}
-
-			for _, principalID := range adminPrincipals {
-				select {
-				case <-ctx.Done():
-					return nil, "", nil, ctx.Err()
-				default:
-				}
-				orgGrant := grant.NewGrant(
-					orgRes,
-					OrgMemberEntitlement,
-					principalID,
-					grant.WithAnnotation(&v2.GrantImmutable{}),
-				)
-				orgGrant.SetSources(v2.GrantSources_builder{
-					Sources: map[string]*v2.GrantSources_GrantSource{
-						groupAdminEntID: {IsDirect: true},
-					},
-				}.Build())
-				rv = append(rv, orgGrant)
-			}
-		}
-
-		nextPage, err := parseLink(nextPageLink)
-		if err != nil {
-			if err.Error() != "no next link found in header" {
-				return nil, "", nil, fmt.Errorf("snyk-connector: failed to parse pagination link: %w", err)
-			}
-			break
-		}
-		if nextPage == "" {
-			break
-		}
-		pageToken = nextPage
-	}
-
-	return rv, "", nil, nil
 }
 
 func newGroupBuilder(client *snyk.Client, orgs []string) *groupBuilder {

--- a/pkg/connector/organizations.go
+++ b/pkg/connector/organizations.go
@@ -15,12 +15,13 @@ import (
 	"github.com/conductorone/baton-snyk/pkg/snyk"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Entitlement names for organization membership and roles.
 const (
 	OrgMemberEntitlement       = "member"
-	OrgAdminEntitlement        = "admin"
 	OrgCollaboratorEntitlement = "collaborator"
 )
 
@@ -52,6 +53,7 @@ func orgResource(_ context.Context, org *snyk.Org, parentID *v2.ResourceId) (*v2
 		rs.WithParentResourceID(parentID),
 		rs.WithAnnotation(
 			&v2.ChildResourceType{ResourceTypeId: invitationResourceType.Id},
+			&v2.ChildResourceType{ResourceTypeId: serviceAccountResourceType.Id},
 		),
 	)
 	if err != nil {
@@ -121,7 +123,7 @@ func (o *orgBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ 
 	// permission entitlements - could contain custom roles
 	roles, err := o.client.ListOrgRoles(ctx)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("failed to list roles in organization: %w", err)
+		return nil, "", nil, fmt.Errorf("snyk-connector: failed to list roles in organization: %w", err)
 	}
 
 	for _, role := range roles {
@@ -138,7 +140,6 @@ func (o *orgBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ 
 }
 
 // Grants returns slice of membership and permission grants for the org.
-// Uses REST API GET /orgs/{org_id}/memberships so only actual org members appear.
 func (o *orgBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
 	var rv []*v2.Grant
@@ -169,11 +170,61 @@ func (o *orgBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *
 		rv = append(rv, grant.NewGrant(resource, m.Relationships.Role.Data.ID, userIDRes))
 	}
 
-	// Parse the next page link from the Link header
 	nextPageURL := parseRestNextLink(link)
 	nextToken, err := bag.NextToken(nextPageURL)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("snyk-connector: failed to create next page token: %w", err)
+	}
+
+	if nextToken == "" && resource.ParentResourceId != nil {
+		groupID := resource.ParentResourceId.Resource
+		groupAdminEntID := fmt.Sprintf("%s:%s:%s", groupResourceType.Id, groupID, AdminRole)
+
+		groupIDRes, err := rs.NewResourceID(groupResourceType, groupID)
+		if err != nil {
+			return nil, "", nil, fmt.Errorf("snyk-connector: failed to create group resource id: %w", err)
+		}
+		rv = append(rv, grant.NewGrant(
+			resource,
+			OrgMemberEntitlement,
+			groupIDRes,
+			grant.WithAnnotation(&v2.GrantExpandable{
+				EntitlementIds: []string{groupAdminEntID},
+				Shallow:        true,
+			}),
+		))
+	}
+
+	// On the last page, emit grants for org-level service accounts.
+	if nextToken == "" {
+		saPageToken := ""
+		for {
+			saResp, saLink, err := o.client.ListOrgServiceAccounts(ctx, resource.Id.Resource, saPageToken)
+			if err != nil {
+				return nil, "", nil, fmt.Errorf("snyk-connector: failed to list org service accounts: %w", err)
+			}
+
+			for _, sa := range saResp.Data {
+				// The org SA endpoint returns group SAs too; only emit org-level grants.
+				if sa.Attributes.Level != "Org" {
+					continue
+				}
+				saIDRes, err := rs.NewResourceID(serviceAccountResourceType, sa.ID)
+				if err != nil {
+					return nil, "", nil, fmt.Errorf("snyk-connector: failed to create service account resource id: %w", err)
+				}
+
+				rv = append(rv, grant.NewGrant(resource, OrgMemberEntitlement, saIDRes))
+				if sa.Attributes.RoleID != "" {
+					rv = append(rv, grant.NewGrant(resource, sa.Attributes.RoleID, saIDRes))
+				}
+			}
+
+			saPageToken = parseRestNextLink(saLink)
+			if saPageToken == "" {
+				break
+			}
+		}
 	}
 
 	return rv, nextToken, nil, nil
@@ -284,19 +335,24 @@ func (o *orgBuilder) Grant(ctx context.Context, principal *v2.Resource, entitlem
 }
 
 func (o *orgBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {
-	l := ctxzap.Extract(ctx)
-
 	principal := grant.Principal
 	entitlement := grant.Entitlement
 
-	if principal.Id.ResourceType != userResourceType.Id {
-		l.Debug(
-			"snyk-connector: only users can have organization entitlements revoked",
-			zap.String("principal_id", principal.Id.String()),
-			zap.String("principal_type", principal.Id.ResourceType),
-		)
+	if principal.Id.ResourceType == serviceAccountResourceType.Id {
+		// Revoking any entitlement from an org SA deletes it from the org.
+		// If the SA is not found (group SA, or already deleted), treat as already revoked.
+		err := o.client.DeleteOrgServiceAccount(ctx, entitlement.Resource.Id.Resource, principal.Id.Resource)
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				return annotations.New(&v2.GrantAlreadyRevoked{}), nil
+			}
+			return nil, fmt.Errorf("snyk-connector: failed to delete org service account: %w", err)
+		}
+		return nil, nil
+	}
 
-		return nil, fmt.Errorf("snyk-connector: only users can have organization entitlements revoked")
+	if principal.Id.ResourceType != userResourceType.Id {
+		return annotations.New(&v2.GrantAlreadyRevoked{}), nil
 	}
 
 	users, err := o.client.ListUsersInOrg(ctx, entitlement.Resource.Id.Resource)

--- a/pkg/connector/organizations.go
+++ b/pkg/connector/organizations.go
@@ -199,6 +199,12 @@ func (o *orgBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *
 	if nextToken == "" {
 		saPageToken := ""
 		for {
+			select {
+			case <-ctx.Done():
+				return nil, "", nil, ctx.Err()
+			default:
+			}
+
 			saResp, saLink, err := o.client.ListOrgServiceAccounts(ctx, resource.Id.Resource, saPageToken)
 			if err != nil {
 				return nil, "", nil, fmt.Errorf("snyk-connector: failed to list org service accounts: %w", err)

--- a/pkg/connector/organizations.go
+++ b/pkg/connector/organizations.go
@@ -199,12 +199,6 @@ func (o *orgBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *
 	if nextToken == "" {
 		saPageToken := ""
 		for {
-			select {
-			case <-ctx.Done():
-				return nil, "", nil, ctx.Err()
-			default:
-			}
-
 			saResp, saLink, err := o.client.ListOrgServiceAccounts(ctx, resource.Id.Resource, saPageToken)
 			if err != nil {
 				return nil, "", nil, fmt.Errorf("snyk-connector: failed to list org service accounts: %w", err)

--- a/pkg/connector/organizations.go
+++ b/pkg/connector/organizations.go
@@ -113,7 +113,7 @@ func (o *orgBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ 
 
 	// membership entitlements
 	assignmentOptions := []ent.EntitlementOption{
-		ent.WithGrantableTo(userResourceType),
+		ent.WithGrantableTo(userResourceType, serviceAccountResourceType),
 		ent.WithDisplayName(fmt.Sprintf("%s %s", resource.DisplayName, OrgMemberEntitlement)),
 		ent.WithDescription(fmt.Sprintf("Member of the %s organization", resource.DisplayName)),
 	}
@@ -128,7 +128,7 @@ func (o *orgBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ 
 
 	for _, role := range roles {
 		permissionOptions := []ent.EntitlementOption{
-			ent.WithGrantableTo(userResourceType),
+			ent.WithGrantableTo(userResourceType, serviceAccountResourceType),
 			ent.WithDisplayName(role.Name),
 			ent.WithDescription(role.Description),
 		}

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -33,6 +33,7 @@ var (
 		Id:          "service_account",
 		DisplayName: "Service Account",
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+		Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
 	}
 
 	// The invitation resource type is for all invitation objects.

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -28,6 +28,13 @@ var (
 		Annotations: annotationsForUserResourceType(),
 	}
 
+	// The service account resource type is for all service account objects (non-human identities).
+	serviceAccountResourceType = &v2.ResourceType{
+		Id:          "service_account",
+		DisplayName: "Service Account",
+		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
+	}
+
 	// The invitation resource type is for all invitation objects.
 	// Requires "org.read", "org.user.read", and "org.user.invite" permissions.
 	// See: https://apidocs.snyk.io/?version=2025-11-05#post-/orgs/-org_id-/invites

--- a/pkg/connector/service_accounts.go
+++ b/pkg/connector/service_accounts.go
@@ -50,6 +50,10 @@ func (s *serviceAccountBuilder) List(ctx context.Context, parentResourceID *v2.R
 		return nil, "", nil, nil
 	}
 
+	if pToken == nil {
+		pToken = &pagination.Token{}
+	}
+
 	bag, page, err := parsePageToken(pToken.Token, &v2.ResourceId{ResourceType: serviceAccountResourceType.Id})
 	if err != nil {
 		return nil, "", nil, err

--- a/pkg/connector/service_accounts.go
+++ b/pkg/connector/service_accounts.go
@@ -1,0 +1,120 @@
+package connector
+
+import (
+	"context"
+	"fmt"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-snyk/pkg/snyk"
+)
+
+type serviceAccountBuilder struct {
+	client *snyk.Client
+}
+
+func (s *serviceAccountBuilder) ResourceType(_ context.Context) *v2.ResourceType {
+	return serviceAccountResourceType
+}
+
+func serviceAccountResource(sa *snyk.ServiceAccountData, parentID *v2.ResourceId) (*v2.Resource, error) {
+	resource, err := rs.NewUserResource(
+		sa.Attributes.Name,
+		serviceAccountResourceType,
+		sa.ID,
+		[]rs.UserTraitOption{
+			rs.WithAccountType(v2.UserTrait_ACCOUNT_TYPE_SERVICE),
+			rs.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
+			rs.WithUserProfile(map[string]interface{}{
+				"auth_type": sa.Attributes.AuthType,
+				"level":     sa.Attributes.Level,
+			}),
+		},
+		rs.WithParentResourceID(parentID),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return resource, nil
+}
+
+// List returns service accounts as resource objects.
+// When the parent is a group resource, group-level service accounts are listed.
+// When the parent is an org resource, org-level service accounts are listed.
+func (s *serviceAccountBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+	if parentResourceID == nil {
+		return nil, "", nil, nil
+	}
+
+	bag, page, err := parsePageToken(pToken.Token, &v2.ResourceId{ResourceType: serviceAccountResourceType.Id})
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	var (
+		saResp *snyk.ServiceAccountListResponse
+		link   string
+	)
+
+	switch parentResourceID.ResourceType {
+	case groupResourceType.Id:
+		saResp, link, err = s.client.ListGroupServiceAccounts(ctx, page)
+		if err != nil {
+			return nil, "", nil, fmt.Errorf("snyk-connector: failed to list group service accounts: %w", err)
+		}
+	case orgResourceType.Id:
+		saResp, link, err = s.client.ListOrgServiceAccounts(ctx, parentResourceID.Resource, page)
+		if err != nil {
+			return nil, "", nil, fmt.Errorf("snyk-connector: failed to list org service accounts for org %s: %w", parentResourceID.Resource, err)
+		}
+	default:
+		return nil, "", nil, nil
+	}
+
+	// Both endpoints return group and org SAs mixed together.
+	// Filter by level so each SA appears under exactly one parent.
+	expectedLevel := "Group"
+	if parentResourceID.ResourceType == orgResourceType.Id {
+		expectedLevel = "Org"
+	}
+
+	var rv []*v2.Resource
+	for i := range saResp.Data {
+		if saResp.Data[i].Attributes.Level != expectedLevel {
+			continue
+		}
+		resource, err := serviceAccountResource(&saResp.Data[i], parentResourceID)
+		if err != nil {
+			return nil, "", nil, fmt.Errorf("snyk-connector: failed to create service account resource: %w", err)
+		}
+		rv = append(rv, resource)
+	}
+
+	nextPageURL := parseRestNextLink(link)
+	nextToken, err := bag.NextToken(nextPageURL)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("snyk-connector: failed to create next page token: %w", err)
+	}
+
+	return rv, nextToken, nil, nil
+}
+
+// Entitlements always returns an empty slice for service accounts.
+func (s *serviceAccountBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+	return nil, "", nil, nil
+}
+
+// Grants always returns an empty slice for service accounts.
+// Grants are emitted by the group and org builders that own the entitlements.
+func (s *serviceAccountBuilder) Grants(_ context.Context, _ *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+	return nil, "", nil, nil
+}
+
+func newServiceAccountBuilder(client *snyk.Client) *serviceAccountBuilder {
+	return &serviceAccountBuilder{
+		client: client,
+	}
+}

--- a/pkg/connector/service_accounts.go
+++ b/pkg/connector/service_accounts.go
@@ -107,7 +107,9 @@ func (s *serviceAccountBuilder) List(ctx context.Context, parentResourceID *v2.R
 	return rv, nextToken, nil, nil
 }
 
+
 // Entitlements always returns an empty slice for service accounts.
+// The serviceAccountResourceType is annotated with SkipEntitlementsAndGrants so the SDK skips these calls.
 func (s *serviceAccountBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
 	return nil, "", nil, nil
 }

--- a/pkg/connector/service_accounts.go
+++ b/pkg/connector/service_accounts.go
@@ -33,6 +33,7 @@ func serviceAccountResource(sa *snyk.ServiceAccountData, parentID *v2.ResourceId
 			}),
 		},
 		rs.WithParentResourceID(parentID),
+		rs.WithExternalID(&v2.ExternalId{Id: sa.ID}),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/service_accounts.go
+++ b/pkg/connector/service_accounts.go
@@ -56,7 +56,7 @@ func (s *serviceAccountBuilder) List(ctx context.Context, parentResourceID *v2.R
 
 	bag, page, err := parsePageToken(pToken.Token, &v2.ResourceId{ResourceType: serviceAccountResourceType.Id})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, fmt.Errorf("snyk-connector: failed to parse page token: %w", err)
 	}
 
 	var (

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -64,6 +64,12 @@ func (u *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 
 	var rv []*v2.Resource
 	for _, user := range users {
+		// Service accounts appear in the group members list with an empty email.
+		// Skip them here; they are synced as service_account resources via ListGroupServiceAccounts.
+		if user.Email == "" {
+			continue
+		}
+
 		uCopy := user
 		resource, err := userResource(&uCopy, parentResourceID)
 		if err != nil {

--- a/pkg/snyk/client.go
+++ b/pkg/snyk/client.go
@@ -86,12 +86,8 @@ func (c *Client) prepareURL(path string) *url.URL {
 }
 
 func (c *Client) prepareRestURL(path string) *url.URL {
-	// Prepare URL for REST API endpoints
 	u := c.baseURL.JoinPath(RestAPI, path)
-	// Add version query parameter
-	q := u.Query()
-	q.Set("version", APIVersion)
-	u.RawQuery = q.Encode()
+	withQueryParam(u, "version", APIVersion)
 	return u
 }
 
@@ -136,21 +132,17 @@ func (c *Client) ListOrgMemberships(ctx context.Context, orgID string, pageToken
 	var err error
 
 	if pageToken != "" {
-		// Use the provided page token URL
-		u, err = url.Parse(pageToken)
+		u, err = parsePageURL(pageToken)
 		if err != nil {
-			return nil, "", fmt.Errorf("snyk: invalid page token: %w", err)
+			return nil, "", err
 		}
 	} else {
-		// Start from the first page
 		path, err := url.JoinPath("orgs", orgID, "memberships")
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to build memberships path: %w", err)
 		}
 		u = c.prepareRestURL(path)
-		q := u.Query()
-		q.Set("limit", "100")
-		u.RawQuery = q.Encode()
+		withQueryParam(u, "limit", "100")
 	}
 
 	var response OrgMembershipListResponse
@@ -246,9 +238,9 @@ func (c *Client) ListGroupServiceAccounts(ctx context.Context, pageToken string)
 	var err error
 
 	if pageToken != "" {
-		u, err = url.Parse(pageToken)
+		u, err = parsePageURL(pageToken)
 		if err != nil {
-			return nil, "", fmt.Errorf("snyk: invalid page token: %w", err)
+			return nil, "", err
 		}
 	} else {
 		path, err := url.JoinPath("groups", c.groupID, "service_accounts")
@@ -256,9 +248,7 @@ func (c *Client) ListGroupServiceAccounts(ctx context.Context, pageToken string)
 			return nil, "", fmt.Errorf("failed to build group service accounts path: %w", err)
 		}
 		u = c.prepareRestURL(path)
-		q := u.Query()
-		q.Set("limit", "100")
-		u.RawQuery = q.Encode()
+		withQueryParam(u, "limit", "100")
 	}
 
 	var response ServiceAccountListResponse
@@ -277,9 +267,9 @@ func (c *Client) ListOrgServiceAccounts(ctx context.Context, orgID string, pageT
 	var err error
 
 	if pageToken != "" {
-		u, err = url.Parse(pageToken)
+		u, err = parsePageURL(pageToken)
 		if err != nil {
-			return nil, "", fmt.Errorf("snyk: invalid page token: %w", err)
+			return nil, "", err
 		}
 	} else {
 		path, err := url.JoinPath("orgs", orgID, "service_accounts")
@@ -287,9 +277,7 @@ func (c *Client) ListOrgServiceAccounts(ctx context.Context, orgID string, pageT
 			return nil, "", fmt.Errorf("failed to build org service accounts path: %w", err)
 		}
 		u = c.prepareRestURL(path)
-		q := u.Query()
-		q.Set("limit", "100")
-		u.RawQuery = q.Encode()
+		withQueryParam(u, "limit", "100")
 	}
 
 	var response ServiceAccountListResponse

--- a/pkg/snyk/client.go
+++ b/pkg/snyk/client.go
@@ -239,6 +239,68 @@ func (c *Client) ListOrgRoles(ctx context.Context) ([]Role, error) {
 	return orgRoles, nil
 }
 
+// ListGroupServiceAccounts lists service accounts for the configured group.
+// pageToken should be a full next-page URL from a previous Link header, or empty for the first page.
+func (c *Client) ListGroupServiceAccounts(ctx context.Context, pageToken string) (*ServiceAccountListResponse, string, error) {
+	var u *url.URL
+	var err error
+
+	if pageToken != "" {
+		u, err = url.Parse(pageToken)
+		if err != nil {
+			return nil, "", fmt.Errorf("snyk: invalid page token: %w", err)
+		}
+	} else {
+		path, err := url.JoinPath("groups", c.groupID, "service_accounts")
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to build group service accounts path: %w", err)
+		}
+		u = c.prepareRestURL(path)
+		q := u.Query()
+		q.Set("limit", "100")
+		u.RawQuery = q.Encode()
+	}
+
+	var response ServiceAccountListResponse
+	link, err := c.getRest(ctx, u, &response, nil)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return &response, link, nil
+}
+
+// ListOrgServiceAccounts lists service accounts for the given organization.
+// pageToken should be a full next-page URL from a previous Link header, or empty for the first page.
+func (c *Client) ListOrgServiceAccounts(ctx context.Context, orgID string, pageToken string) (*ServiceAccountListResponse, string, error) {
+	var u *url.URL
+	var err error
+
+	if pageToken != "" {
+		u, err = url.Parse(pageToken)
+		if err != nil {
+			return nil, "", fmt.Errorf("snyk: invalid page token: %w", err)
+		}
+	} else {
+		path, err := url.JoinPath("orgs", orgID, "service_accounts")
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to build org service accounts path: %w", err)
+		}
+		u = c.prepareRestURL(path)
+		q := u.Query()
+		q.Set("limit", "100")
+		u.RawQuery = q.Encode()
+	}
+
+	var response ServiceAccountListResponse
+	link, err := c.getRest(ctx, u, &response, nil)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return &response, link, nil
+}
+
 // GetOrgRole retrieves a single org role by ID using the REST API.
 func (c *Client) GetOrgRole(ctx context.Context, roleID string) (*Role, error) {
 	path, err := url.JoinPath("tenants", c.groupID, "roles", roleID)
@@ -403,6 +465,18 @@ func (c *Client) ListInvites(ctx context.Context, orgID string) ([]InviteRespons
 	return response.Data, nil
 }
 
+// DeleteOrgServiceAccount deletes a service account from an org via the REST API.
+// See: https://apidocs.snyk.io/?version=2025-11-05#delete-/orgs/-org_id-/service_accounts/-serviceaccount_id-
+func (c *Client) DeleteOrgServiceAccount(ctx context.Context, orgID, serviceAccountID string) error {
+	path, err := url.JoinPath("orgs", orgID, "service_accounts", serviceAccountID)
+	if err != nil {
+		return fmt.Errorf("failed to build service account path: %w", err)
+	}
+
+	_, err = c.deleteRest(ctx, c.prepareRestURL(path))
+	return err
+}
+
 // DeleteInvite cancels/deletes an invitation by its ID.
 func (c *Client) DeleteInvite(ctx context.Context, orgID, inviteID string) error {
 	path, err := url.JoinPath("orgs", orgID, OrgInvitesEndpoint, inviteID)
@@ -411,11 +485,7 @@ func (c *Client) DeleteInvite(ctx context.Context, orgID, inviteID string) error
 	}
 
 	_, err = c.deleteRest(ctx, c.prepareRestURL(path))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (c *Client) get(ctx context.Context, urlAddress *url.URL, response interface{}, vars []Vars) (string, error) {

--- a/pkg/snyk/helpers.go
+++ b/pkg/snyk/helpers.go
@@ -1,0 +1,22 @@
+package snyk
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// withQueryParam sets a query parameter on the given URL in place.
+func withQueryParam(u *url.URL, key, value string) {
+	q := u.Query()
+	q.Set(key, value)
+	u.RawQuery = q.Encode()
+}
+
+// parsePageURL parses a full next-page URL string returned in a Link header.
+func parsePageURL(pageToken string) (*url.URL, error) {
+	u, err := url.Parse(pageToken)
+	if err != nil {
+		return nil, fmt.Errorf("snyk: invalid page token: %w", err)
+	}
+	return u, nil
+}

--- a/pkg/snyk/models.go
+++ b/pkg/snyk/models.go
@@ -128,48 +128,6 @@ type InviteListResponse struct {
 	Data []InviteResponseData `json:"data"`
 }
 
-// GroupMembershipListResponse is the REST API response for GET /groups/{group_id}/memberships.
-// See https://apidocs.snyk.io/?version=2025-11-05#get-/groups/-group_id-/memberships
-type GroupMembershipListResponse struct {
-	Data []GroupMembershipData `json:"data"`
-}
-
-// GroupMembershipData is a single group membership in the REST API response.
-// Role is under relationships.role.data.attributes.name (not in top-level attributes).
-type GroupMembershipData struct {
-	ID            string                       `json:"id"`
-	Type          string                       `json:"type"`
-	Attributes    GroupMembershipAttributes    `json:"attributes"`
-	Relationships GroupMembershipRelationships `json:"relationships"`
-}
-
-// GroupMembershipAttributes contains created_at; role comes from relationships.role.
-type GroupMembershipAttributes struct {
-	CreatedAt string `json:"created_at"`
-}
-
-// GroupMembershipRelationships holds group, role, and user references.
-type GroupMembershipRelationships struct {
-	Role GroupMembershipRoleRef `json:"role"`
-}
-
-// GroupMembershipRoleRef is the role relationship (data.attributes.name = role name, e.g. "admin").
-type GroupMembershipRoleRef struct {
-	Data *GroupMembershipRoleData `json:"data"`
-}
-
-// GroupMembershipRoleData contains the role id, type, and attributes (name).
-type GroupMembershipRoleData struct {
-	ID         string                  `json:"id"`
-	Type       string                  `json:"type"`
-	Attributes GroupMembershipRoleAttr `json:"attributes"`
-}
-
-// GroupMembershipRoleAttr has the role name ("The name of the role").
-type GroupMembershipRoleAttr struct {
-	Name string `json:"name"`
-}
-
 // OrgMembershipListResponse is the REST API response for GET /orgs/{org_id}/memberships.
 // Matches the JSON: data[] of type "org_membership" with relationships org, user, role.
 type OrgMembershipListResponse struct {
@@ -210,4 +168,24 @@ type OrgMembershipRefData struct {
 	ID         string                 `json:"id"`
 	Type       string                 `json:"type"`
 	Attributes map[string]interface{} `json:"attributes,omitempty"`
+}
+
+// ServiceAccountListResponse is the REST API response for listing service accounts.
+type ServiceAccountListResponse struct {
+	Data []ServiceAccountData `json:"data"`
+}
+
+// ServiceAccountData is a single service account in the REST API response.
+type ServiceAccountData struct {
+	ID         string              `json:"id"`
+	Type       string              `json:"type"`
+	Attributes ServiceAccountAttrs `json:"attributes"`
+}
+
+// ServiceAccountAttrs contains the service account attributes from the REST API.
+type ServiceAccountAttrs struct {
+	Name     string `json:"name"`
+	AuthType string `json:"auth_type"`
+	Level    string `json:"level"` // "Group" or "Org"
+	RoleID   string `json:"role_id"`
 }


### PR DESCRIPTION
Heads up: This update will result in the loss of certain grants for some customers. The previous behavior treated service accounts as users and did not differentiate by level (group/org), leading to incorrectly assigned permissions
<img width="620" height="480" alt="image" src="https://github.com/user-attachments/assets/06962640-c3e9-430c-9e43-6e843eac42be" />
<img width="1282" height="481" alt="image" src="https://github.com/user-attachments/assets/92180de6-f72f-4e03-9931-f7d88774a10d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service accounts are now first-class resources: listable at group and org levels, show metadata (account type, level, status), and can be removed from orgs.

* **Bug Fixes / Improvements**
  * Grant emission refined to distinguish group admins, group-level service accounts, and org users, improving grant accuracy and propagation.
  * User listings now skip entries without emails to avoid duplicate service-account users.
  * Error messages uniformly prefixed for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->