### PR TITLE
feat: mark invitation resource type as skipSyncAnomalyDetection

### DIFF
--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -52,6 +52,7 @@ var (
 				},
 			},
 			&v2.SkipEntitlementsAndGrants{},
+			&v2.SkipSyncAnomalyDetection{},
 		),
 	}
 )


### PR DESCRIPTION
## Summary
Mark the `invitation` resource type with the `SkipSyncAnomalyDetection` annotation. Counts on this type can legitimately drop between syncs as pending invitees accept and are reclassified as users. Without this annotation, sync anomaly detection would flag those expected drops.

The `user` resource type intentionally remains anomaly-checked.

## Test plan
- [x] `go build ./...`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
