### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -52,9 +52,8 @@ func groupResource(_ context.Context, group *snyk.Group) (*v2.Resource, error) {
 		group.Name,
 		groupResourceType,
 		group.ID,
-		[]rs.GroupTraitOption{
-			rs.WithGroupProfile(profile),
-		},
+		[]rs.GroupTraitOption{},
+		rs.WithResourceProfile(profile),
 		rs.WithAnnotation(
 			&v2.ChildResourceType{ResourceTypeId: orgResourceType.Id},
 			&v2.ChildResourceType{ResourceTypeId: userResourceType.Id},

--- a/pkg/connector/invitations.go
+++ b/pkg/connector/invitations.go
@@ -168,10 +168,8 @@ func createInvitationResource(invite *snyk.InviteResponseData, orgID string, par
 	}
 
 	userTraitOptions := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
 		rs.WithEmail(invite.Attributes.Email, true),
 		rs.WithUserLogin(invite.Attributes.Email),
-		rs.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
 	}
 
 	resourceOptions := []rs.ResourceOption{}
@@ -185,7 +183,7 @@ func createInvitationResource(invite *snyk.InviteResponseData, orgID string, par
 		invitationResourceType,
 		invite.ID,
 		userTraitOptions,
-		resourceOptions...,
+		append(resourceOptions, rs.WithResourceProfile(profile), rs.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""))...,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/invitations.go
+++ b/pkg/connector/invitations.go
@@ -172,7 +172,10 @@ func createInvitationResource(invite *snyk.InviteResponseData, orgID string, par
 		rs.WithUserLogin(invite.Attributes.Email),
 	}
 
-	resourceOptions := []rs.ResourceOption{}
+	resourceOptions := []rs.ResourceOption{
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""),
+	}
 	if parentID != nil {
 		resourceOptions = append(resourceOptions, rs.WithParentResourceID(parentID))
 	}
@@ -183,7 +186,7 @@ func createInvitationResource(invite *snyk.InviteResponseData, orgID string, par
 		invitationResourceType,
 		invite.ID,
 		userTraitOptions,
-		append(resourceOptions, rs.WithResourceProfile(profile), rs.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""))...,
+		resourceOptions...,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/organizations.go
+++ b/pkg/connector/organizations.go
@@ -41,15 +41,14 @@ func orgResource(_ context.Context, org *snyk.Org, parentID *v2.ResourceId) (*v2
 		"url":         org.URL,
 	}
 
-	options := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	options := []rs.GroupTraitOption{}
 
 	resource, err := rs.NewGroupResource(
 		org.Name,
 		orgResourceType,
 		org.ID,
 		options,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentID),
 		rs.WithAnnotation(
 			&v2.ChildResourceType{ResourceTypeId: invitationResourceType.Id},

--- a/pkg/connector/service_accounts.go
+++ b/pkg/connector/service_accounts.go
@@ -26,12 +26,12 @@ func serviceAccountResource(sa *snyk.ServiceAccountData, parentID *v2.ResourceId
 		sa.ID,
 		[]rs.UserTraitOption{
 			rs.WithAccountType(v2.UserTrait_ACCOUNT_TYPE_SERVICE),
-			rs.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
-			rs.WithUserProfile(map[string]interface{}{
-				"auth_type": sa.Attributes.AuthType,
-				"level":     sa.Attributes.Level,
-			}),
 		},
+		rs.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""),
+		rs.WithResourceProfile(map[string]interface{}{
+			"auth_type": sa.Attributes.AuthType,
+			"level":     sa.Attributes.Level,
+		}),
 		rs.WithParentResourceID(parentID),
 		rs.WithExternalID(&v2.ExternalId{Id: sa.ID}),
 	)
@@ -106,7 +106,6 @@ func (s *serviceAccountBuilder) List(ctx context.Context, parentResourceID *v2.R
 
 	return rv, nextToken, nil, nil
 }
-
 
 // Entitlements always returns an empty slice for service accounts.
 // The serviceAccountResourceType is annotated with SkipEntitlementsAndGrants so the SDK skips these calls.

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -31,7 +31,9 @@ func userResource(user *snyk.GroupUser, parentID *v2.ResourceId) (*v2.Resource, 
 		rs.WithUserLogin(user.Email),
 	}
 
-	resourceOptions := []rs.ResourceOption{}
+	resourceOptions := []rs.ResourceOption{
+		rs.WithResourceProfile(profile),
+	}
 	if parentID != nil {
 		resourceOptions = append(resourceOptions, rs.WithParentResourceID(parentID))
 	}
@@ -41,7 +43,7 @@ func userResource(user *snyk.GroupUser, parentID *v2.ResourceId) (*v2.Resource, 
 		userResourceType,
 		user.ID,
 		userTraitOptions,
-		append(resourceOptions, rs.WithResourceProfile(profile))...,
+		resourceOptions...,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -27,7 +27,6 @@ func userResource(user *snyk.GroupUser, parentID *v2.ResourceId) (*v2.Resource, 
 	}
 
 	userTraitOptions := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
 		rs.WithEmail(user.Email, true),
 		rs.WithUserLogin(user.Email),
 	}
@@ -42,7 +41,7 @@ func userResource(user *snyk.GroupUser, parentID *v2.ResourceId) (*v2.Resource, 
 		userResourceType,
 		user.ID,
 		userTraitOptions,
-		resourceOptions...,
+		append(resourceOptions, rs.WithResourceProfile(profile))...,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
